### PR TITLE
Update dependency versions + RabbitMQ from secret

### DIFF
--- a/cloudlaunchserver/requirements.yaml
+++ b/cloudlaunchserver/requirements.yaml
@@ -1,8 +1,8 @@
 dependencies:
     - name: postgresql
       repository: https://kubernetes-charts.storage.googleapis.com/
-      version: 8.1.2
+      version: 8.3.0
     - name: rabbitmq-ha
       repository: https://kubernetes-charts.storage.googleapis.com/
-      version: 1.22.2
+      version: 1.38.2
       alias: rabbitmq

--- a/cloudlaunchserver/templates/_helpers.tpl
+++ b/cloudlaunchserver/templates/_helpers.tpl
@@ -70,8 +70,18 @@ Return django fernet keys
 {{- end -}}
 
 {{- define "cloudlaunchserver.envvars" }}
+            - name: RABBITMQ_USER
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .Release.Name }}-rabbitmq"
+                  key: rabbitmq-username
+            - name: RABBITMQ_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .Release.Name }}-rabbitmq"
+                  key: rabbitmq-password
             - name: CELERY_BROKER_URL
-              value: amqp://{{ .Values.rabbitmq.rabbitmqUsername }}:{{ .Values.rabbitmq.rabbitmqPassword }}@{{ template "rabbitmq.fullname" . }}:5672/
+              value: amqp://$(RABBITMQ_USER):$(RABBITMQ_PASS)@{{ template "rabbitmq.fullname" . }}:5672/
             - name: DJANGO_SETTINGS_MODULE
               value: {{ .Values.django_settings_module | default "cloudlaunchserver.settings_prod" | quote }}
             - name: {{ .Values.env_prefix | default "CLOUDLAUNCH" | upper }}_DB_ENGINE

--- a/cloudlaunchserver/values.yaml
+++ b/cloudlaunchserver/values.yaml
@@ -89,7 +89,8 @@ affinity: {}
 
 rabbitmq:
   rabbitmqUsername: notAGuest
-  rabbitmqPassword: aRandomPassword
+  # Will autogenerate if not set
+  # rabbitmqPassword: aRandomPassword
   rabbitmqErlangCookie: mustRemainSameBetweenUpgrades
   replicaCount: 1
 


### PR DESCRIPTION
Tested change with cloudman chart by launching GVL.
Should we make username required or leave `notAGuest` as a default? (`guest` would be default otherwise)
Also, should I bump the version?