### PR TITLE
extra_env handling

### DIFF
--- a/cloudlaunchserver/templates/_helpers.tpl
+++ b/cloudlaunchserver/templates/_helpers.tpl
@@ -7,6 +7,16 @@ Expand the name of the chart.
 {{- end -}}
 
 {{/*
+Remove newlines inserted by toYaml from within templating brackets
+*/}}
+{{- define "cloudlaunchserver.cleanExtraEnvs" -}}
+{{- if .Values.extra_env }}
+{{- $nowhitespace := (regexReplaceAll "{{\\s*([^}\\n]+)\\n?([^}\\n]+)?\\n?([^}\\n]+)?\\n?([^}\\n]+)?\\n?([^}\\n]+)?\\s*}}" (toYaml .Values.extra_env) "{{$1 $2 $3 $4 $5}}") -}}
+{{- tpl $nowhitespace . | nindent 12 -}}
+{{- end }}
+{{- end -}}
+
+{{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 If release name contains chart name it will be used as a full name.

--- a/cloudlaunchserver/templates/cl-celery-deployment.yaml
+++ b/cloudlaunchserver/templates/cl-celery-deployment.yaml
@@ -58,10 +58,7 @@ spec:
               protocol: TCP
           env:
           {{- include "cloudlaunchserver.envvars" . }}
-{{- if .Values.extra_env }}
-{{- $nowhitespace := (regexReplaceAll "{{\\s*([^}\\n]+)\\n?([^}\\n]+)?\\n?([^}\\n]+)?\\n?([^}\\n]+)?\\n?([^}\\n]+)?\\s*}}" (toYaml .Values.extra_env) "{{$1 $2 $3 $4 $5}}") -}}
-{{- tpl $nowhitespace . | nindent 12 -}}
-{{- end }}
+          {{- include "cloudlaunchserver.cleanExtraEnvs" . }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
     {{- with .Values.nodeSelector }}

--- a/cloudlaunchserver/templates/cl-celery-deployment.yaml
+++ b/cloudlaunchserver/templates/cl-celery-deployment.yaml
@@ -58,11 +58,9 @@ spec:
               protocol: TCP
           env:
           {{- include "cloudlaunchserver.envvars" . }}
-{{- range $key, $val := .Values.extra_env }}
-{{- if $val }}
-            - name: {{ $key | upper }}
-              value: "{{ tpl $val $ }}"
-{{- end }}
+{{- if .Values.extra_env }}
+{{- $nowhitespace := (regexReplaceAll "{{\\s*([^}\\n]+)\\n?([^}\\n]+)?\\n?([^}\\n]+)?\\n?([^}\\n]+)?\\n?([^}\\n]+)?\\s*}}" (toYaml .Values.extra_env) "{{$1 $2 $3 $4 $5}}") -}}
+{{- tpl $nowhitespace . | nindent 12 -}}
 {{- end }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}

--- a/cloudlaunchserver/templates/cl-server-deployment.yaml
+++ b/cloudlaunchserver/templates/cl-server-deployment.yaml
@@ -45,11 +45,9 @@ spec:
             - name: CURL_CA_BUNDLE
               value: ""
           {{- include "cloudlaunchserver.envvars" . }}
-{{- range $key, $val := .Values.extra_env }}
-{{- if $val }}
-            - name: {{ $key | upper }}
-              value: "{{ tpl $val $ }}"
-{{- end }}
+{{- if .Values.extra_env }}
+{{- $nowhitespace := (regexReplaceAll "{{\\s*([^}\\n]+)\\n?([^}\\n]+)?\\n?([^}\\n]+)?\\n?([^}\\n]+)?\\n?([^}\\n]+)?\\s*}}" (toYaml .Values.extra_env) "{{$1 $2 $3 $4 $5}}") -}}
+{{- tpl $nowhitespace . | nindent 12 -}}
 {{- end }}
           volumeMounts:
             - name: initial-data
@@ -139,11 +137,9 @@ spec:
             - name: HELMSMAN_AUTO_DEPLOY
               value: "true"
           {{- include "cloudlaunchserver.envvars" . }}
-{{- range $key, $val := .Values.extra_env }}
-{{- if $val }}
-            - name: {{ $key | upper }}
-              value: "{{ tpl $val $ }}"
-{{- end }}
+{{- if .Values.extra_env }}
+{{- $nowhitespace := (regexReplaceAll "{{\\s*([^}\\n]+)\\n?([^}\\n]+)?\\n?([^}\\n]+)?\\n?([^}\\n]+)?\\n?([^}\\n]+)?\\s*}}" (toYaml .Values.extra_env) "{{$1 $2 $3 $4 $5}}") -}}
+{{- tpl $nowhitespace . | nindent 12 -}}
 {{- end }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}

--- a/cloudlaunchserver/templates/cl-server-deployment.yaml
+++ b/cloudlaunchserver/templates/cl-server-deployment.yaml
@@ -45,10 +45,7 @@ spec:
             - name: CURL_CA_BUNDLE
               value: ""
           {{- include "cloudlaunchserver.envvars" . }}
-{{- if .Values.extra_env }}
-{{- $nowhitespace := (regexReplaceAll "{{\\s*([^}\\n]+)\\n?([^}\\n]+)?\\n?([^}\\n]+)?\\n?([^}\\n]+)?\\n?([^}\\n]+)?\\s*}}" (toYaml .Values.extra_env) "{{$1 $2 $3 $4 $5}}") -}}
-{{- tpl $nowhitespace . | nindent 12 -}}
-{{- end }}
+          {{- include "cloudlaunchserver.cleanExtraEnvs" . }}
           volumeMounts:
             - name: initial-data
               mountPath: /app/initial_data
@@ -137,10 +134,7 @@ spec:
             - name: HELMSMAN_AUTO_DEPLOY
               value: "true"
           {{- include "cloudlaunchserver.envvars" . }}
-{{- if .Values.extra_env }}
-{{- $nowhitespace := (regexReplaceAll "{{\\s*([^}\\n]+)\\n?([^}\\n]+)?\\n?([^}\\n]+)?\\n?([^}\\n]+)?\\n?([^}\\n]+)?\\s*}}" (toYaml .Values.extra_env) "{{$1 $2 $3 $4 $5}}") -}}
-{{- tpl $nowhitespace . | nindent 12 -}}
-{{- end }}
+          {{- include "cloudlaunchserver.cleanExtraEnvs" . }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
     {{- with .Values.nodeSelector }}

--- a/cloudlaunchserver/values.yaml
+++ b/cloudlaunchserver/values.yaml
@@ -27,6 +27,16 @@ fernet_keys: []
 
 # Extra environment variables to pass to container
 extra_env: []
+# extra_env:
+#   - name: OIDC_CLIENT_ID
+#     value: "cloudman"
+#   - name: OIDC_PUBLIC_URI
+#     value: "{{.Values.ingress.protocol}}://{{.Values.global.domain | default (index .Values.ingress.hosts 0)}}/cloudman"
+#   - name: SOME_PASSWORD
+#     valueFrom:
+#       secretKeyRef:
+#         name: "{{ .Release.Name }}-service-password"
+#         key: password
 
 extra_init_scripts: {}
 # extra_init_scripts:
@@ -58,28 +68,28 @@ service:
 ingress:
   enabled: false
   annotations: {}
-    # kubernetes.io/ingress.class: nginx
-    # kubernetes.io/tls-acme: "true"
+  #   kubernetes.io/ingress.class: nginx
+  #   kubernetes.io/tls-acme: "true"
   path: /
   hosts:
     - ~
   protocol: https
   tls: []
-  #  - secretName: chart-example-tls
-  #    hosts:
-  #      - chart-example.local
+#    - secretName: chart-example-tls
+#      hosts:
+#        - chart-example.local
 
 resources: {}
-  # We usually recommend not to specify default resources and to leave this as a conscious
-  # choice for the user. This also increases chances charts run on environments with little
-  # resources, such as Minikube. If you do want to specify resources, uncomment the following
-  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-  # limits:
-  #  cpu: 100m
-  #  memory: 128Mi
-  # requests:
-  #  cpu: 100m
-  #  memory: 128Mi
+#   We usually recommend not to specify default resources and to leave this as a conscious
+#   choice for the user. This also increases chances charts run on environments with little
+#   resources, such as Minikube. If you do want to specify resources, uncomment the following
+#   lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+#   limits:
+#    cpu: 100m
+#    memory: 128Mi
+#   requests:
+#    cpu: 100m
+#    memory: 128Mi
 
 nodeSelector: {}
 
@@ -89,8 +99,8 @@ affinity: {}
 
 rabbitmq:
   rabbitmqUsername: notAGuest
-  # Will autogenerate if not set
-  # rabbitmqPassword: aRandomPassword
+#   Will autogenerate if not set
+#   rabbitmqPassword: aRandomPassword
   rabbitmqErlangCookie: mustRemainSameBetweenUpgrades
   replicaCount: 1
 
@@ -98,11 +108,11 @@ postgresql:
   enabled: true
   postgresqlDatabase: cloudlaunch
   postgresqlUsername: cloudlaunch
-  # Password will be auto-generated if not specified, then stored in a secret
-  # postgresqlPassword: some_pass
-  # The postgres superuser password will not be set if not specified. If you need a postgres superuser,
-  # this should be set at launch (eg: for access to manually modify databases on the running server)
-  # postgresqlPostgresPassword: admin_pass
+#   Password will be auto-generated if not specified, then stored in a secret
+#   postgresqlPassword: some_pass
+#   The postgres superuser password will not be set if not specified. If you need a postgres superuser,
+#   this should be set at launch (eg: for access to manually modify databases on the running server)
+#   postgresqlPostgresPassword: admin_pass
   persistence:
     accessMode: ReadWriteMany
 

--- a/cloudlaunchserver/values.yaml
+++ b/cloudlaunchserver/values.yaml
@@ -29,9 +29,7 @@ fernet_keys: []
 extra_env: []
 # extra_env:
 #   - name: OIDC_CLIENT_ID
-#     value: "cloudman"
-#   - name: OIDC_PUBLIC_URI
-#     value: "{{.Values.ingress.protocol}}://{{.Values.global.domain | default (index .Values.ingress.hosts 0)}}/cloudman"
+#     value: "{{.Release.Name}}-cloudman"
 #   - name: SOME_PASSWORD
 #     valueFrom:
 #       secretKeyRef:

--- a/cloudlaunchserver/values.yaml
+++ b/cloudlaunchserver/values.yaml
@@ -26,7 +26,7 @@ secret_key:
 fernet_keys: []
 
 # Extra environment variables to pass to container
-extra_env: {}
+extra_env: []
 
 extra_init_scripts: {}
 # extra_init_scripts:


### PR DESCRIPTION
Accept extra env variables from secrets as well, and more generally follow the way it is passed in other charts vs just key-value pair.
The `nowhitespace` regex removes the newlines added by `toYaml` inside the function to avoid error: `error calling tpl: error during tpl function execution for "......" unclosed action` due to the newlines inserted within templating brackets: `  value: '{{.Values.ingress.protocol}}://{{.Values.global.domain | default (index\n    .Values.ingress.hosts 0)}}/auth/realms/master'`
the `\n` in `index\n` was added by `toYaml` which is needed for tpl to be able to process the map. The regex should remove up to 4 newlines added. The newline is generally added around the 80th character, so removing 4 newlines should safely allow expressions under 280 characters long