### PR TITLE
Ingress minor tweaks

### DIFF
--- a/cloudlaunch/templates/ingress.yaml
+++ b/cloudlaunch/templates/ingress.yaml
@@ -6,7 +6,7 @@
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
-  name: {{ $fullName }}
+  name: {{ $fullName }}-ui
   labels:
     app: {{ template "cloudlaunch.name" . }}
     chart: {{ template "cloudlaunch.chart" . }}

--- a/cloudlaunch/values.yaml
+++ b/cloudlaunch/values.yaml
@@ -15,8 +15,8 @@ container_name: cloudlaunch
 
 ingress:
   enabled: true
-  annotations:
-    kubernetes.io/ingress.class: nginx
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
   path: /
   hosts:


### PR DESCRIPTION
Added `-ui` to name because name was interfering with another ingress (i think default Keycloak ingress).
Removed the default annotation cause it interferes with the GKE LoadBalancer default. Added to gvl config: https://github.com/galaxyproject/cloudlaunch-registry/pull/17
