### PR TITLE
Updated doc page for ChemicalToolBox.

### DIFF
--- a/cloudlaunchserver/data/2_appliances.json
+++ b/cloudlaunchserver/data/2_appliances.json
@@ -708,7 +708,7 @@
     "summary": "Galaxy tailored for cheminformatics",
     "maintainer": "bjoern.gruening@gmail.com",
     "description": "The ChemicalToolBoX is a set of tools integrated into the Galaxy-workflow-management system to enable researchers easy-to-use, reproducible, and transparent access to cheminformatics libraries and drug discovery tools. It includes standard applications for similarity and substructure searches, clustering of compounds, prediction of properties and descriptors, filtering, and many other tools that range from drug-likeness classification to fragmentation and fragment-merging. By combinating the various tools many more powerful applications can be designed.",
-    "info_url": "https://galaxyproject.org/chemical-tool-box/",
+    "info_url": "https://galaxyproject.org/use/chemicaltoolbox/",
     "icon_url": "https://i.imgur.com/NhIZvB1.png",
     "default_launch_config": "",
     "default_version": 29,


### PR DESCRIPTION
The old doc page was merged into platform directory entry in Galaxy Hub.