### PR TITLE
Adding Centralized CI

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -1,0 +1,30 @@
+name: Package
+on:
+  pull_request_target:
+    types: [closed]
+jobs:
+  package:
+    name: Package and push
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+           persist-credentials: false
+      - uses: cloudve/helm-ci@master
+        with:
+          chart-name: cloudlaunchserver
+          charts-repo: cloudve/helm-charts
+          github-token: ${{ secrets.CHARTS_TOKEN }}
+          charts-token: ${{ secrets.CHARTS_TOKEN }}
+          github-labels: ${{ join(github.event.pull_request.labels.*.name, ', ') }}
+          git-branch: ${{ github.event.pull_request.base.ref }}
+      - uses: cloudve/helm-ci@depbump
+        with:
+          chart-name: cloudlaunch
+          dependency-name: cloudlaunchserver
+          charts-repo: cloudve/helm-charts
+          github-token: ${{ secrets.CHARTS_TOKEN }}
+          charts-token: ${{ secrets.CHARTS_TOKEN }}
+          github-labels: ${{ join(github.event.pull_request.labels.*.name, ', ') }}
+          git-branch: ${{ github.event.pull_request.base.ref }}
+

--- a/cloudlaunch/Chart.yaml
+++ b/cloudlaunch/Chart.yaml
@@ -1,10 +1,10 @@
 apiVersion: v2
 name: cloudlaunch
-version: 0.4.0
+version: 0.5.0
 appVersion: "2.0.2"
 description: A Helm chart for CloudLaunch, including the server and web UI
 home: http://cloudlaunch.cloudve.org/
 dependencies:
     - name: cloudlaunchserver
       repository: https://raw.githubusercontent.com/CloudVE/helm-charts/master
-      version: 0.4.0
+      version: 0.5.0

--- a/cloudlaunch/Chart.yaml
+++ b/cloudlaunch/Chart.yaml
@@ -1,5 +1,10 @@
+apiVersion: v2
 name: cloudlaunch
 version: 0.4.0
+appVersion: "2.0.2"
 description: A Helm chart for CloudLaunch, including the server and web UI
 home: http://cloudlaunch.cloudve.org/
-appVersion: 2.0.2
+dependencies:
+    - name: cloudlaunchserver
+      repository: https://raw.githubusercontent.com/CloudVE/helm-charts/master
+      version: 0.4.0

--- a/cloudlaunch/requirements.yaml
+++ b/cloudlaunch/requirements.yaml
@@ -1,4 +1,0 @@
-dependencies:
-    - name: cloudlaunchserver
-      repository: https://raw.githubusercontent.com/CloudVE/helm-charts/master
-      version: 0.4.0

--- a/cloudlaunchserver/Chart.lock
+++ b/cloudlaunchserver/Chart.lock
@@ -1,0 +1,9 @@
+dependencies:
+- name: postgresql
+  repository: https://charts.bitnami.com/bitnami
+  version: 9.8.7
+- name: rabbitmq-ha
+  repository: https://charts.helm.sh/stable
+  version: 1.38.2
+digest: sha256:c4724e44ab98fe14bca28250248b60b1e69c0d673a25f524a84c738922caa91f
+generated: "2021-03-10T05:00:48.431462849Z"

--- a/cloudlaunchserver/Chart.yaml
+++ b/cloudlaunchserver/Chart.yaml
@@ -1,5 +1,14 @@
+apiVersion: v2
 name: cloudlaunchserver
 version: 0.4.0
+appVersion: "2.0.2"
 description: A Helm chart for the CloudLaunch server/api component
 home: http://cloudlaunch.cloudve.org/
-appVersion: 2.0.2
+dependencies:
+    - name: postgresql
+      repository: https://charts.bitnami.com/bitnami
+      version: 9.8.7
+    - name: rabbitmq-ha
+      repository: https://charts.helm.sh/stable
+      version: 1.38.2
+      alias: rabbitmq

--- a/cloudlaunchserver/Chart.yaml
+++ b/cloudlaunchserver/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: cloudlaunchserver
-version: 0.4.0
+version: 0.5.0
 appVersion: "2.0.2"
 description: A Helm chart for the CloudLaunch server/api component
 home: http://cloudlaunch.cloudve.org/

--- a/cloudlaunchserver/requirements.yaml
+++ b/cloudlaunchserver/requirements.yaml
@@ -1,8 +1,0 @@
-dependencies:
-    - name: postgresql
-      repository: https://charts.bitnami.com/bitnami
-      version: 9.8.7
-    - name: rabbitmq-ha
-      repository: https://charts.helm.sh/stable
-      version: 1.38.2
-      alias: rabbitmq

--- a/cloudlaunchserver/values.yaml
+++ b/cloudlaunchserver/values.yaml
@@ -4,7 +4,7 @@
 replicaCount: 1
 image:
   repository: cloudve/cloudlaunch-server
-  tag: test
+  tag: latest
   pullPolicy: IfNotPresent
 
 # What initial data to import through django loaddata on startup.

--- a/cloudlaunchserver/values.yaml
+++ b/cloudlaunchserver/values.yaml
@@ -4,7 +4,7 @@
 replicaCount: 1
 image:
   repository: cloudve/cloudlaunch-server
-  tag: latest
+  tag: test
   pullPolicy: IfNotPresent
 
 # What initial data to import through django loaddata on startup.


### PR DESCRIPTION
Works for both, but needs to bump version in both requirements and Chart.yaml. Figured we could just wait to move requirements into the same file for Helm 3 and then I can change it to just bump both and it will work to package and version both together!